### PR TITLE
Allow installation with React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   "peerDependencies": {
     "final-form": "^4.20.0",
     "final-form-set-field-data": "^1.0.2",
-    "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
     "react-final-form": "^6.5.0"
   }
 }


### PR DESCRIPTION
The current peer deps don't include React 18, which means that package-manager-specific overrides workarounds are needed to get it to install with React 18.