### PR TITLE
fix: fix TS type of useGracefulField

### DIFF
--- a/src/useGracefulField.d.ts
+++ b/src/useGracefulField.d.ts
@@ -13,7 +13,7 @@ export type UseGracefulFieldProps<
   InputValue = any
 > = UseGracefulFieldConfig<FieldValue, InputValue>
 
-export function useGracefulField<
+export default function useGracefulField<
   FieldValue = any,
   T extends HTMLElement = HTMLElement,
   InputValue = FieldValue


### PR DESCRIPTION
This is a fix for #3.

I saw two options for the fix:

1. Modify `index.d.ts` so it pulls the named export from `useGracefulField`
2. Modify `useGracefulField.d.ts` so it goes back to a default export instead of a named export.

I went with 2 for consistency because GracefulField.d.ts is still using a default export.